### PR TITLE
fix most trivial differences with bevy 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 
 [dependencies]
 # TODO: Limit the crates dependencies (mainly to reduce compile times)
-bevy = { path = "../bevy" }
+bevy={git="https://github.com/bevyengine/bevy", branch="main"}
 
 smallvec = "1.6.1"
 crossbeam = "0.8.0"
 
 [dev-dependencies] 
-bevy_flycam = { path = "../bevy_flycam" }
+# bevy_flycam = { path = "../bevy_flycam" }
 
 [[example]]
 name = "showcase"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ fn my_system(gizmos: Res<GizmosCommandBuffer>, ...) {
 2. Immediate and Persistent Mode's
 
 ```rust
-fn startup_system(commands: &mut Commands) {
+fn startup_system(mut commands: Commands) {
     commands.spawn(PbrBundle { ... }) // The object
         .with_children(|c| c.spawn(
             GizmoBundle { // And his gizmo

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -70,7 +70,7 @@ fn main() {
         .run();
 }
 
-fn setup(commands: &mut Commands) {
+fn setup(mut commands: Commands) {
     commands
         .spawn(LightBundle {
             transform: Transform::from_xyz(4.0, 8.0, 4.0),
@@ -83,7 +83,7 @@ fn setup(commands: &mut Commands) {
         .with(FlyCam);
 }
 
-fn persistent_gizmos(commands: &mut Commands) {
+fn persistent_gizmos(mut commands: Commands) {
     commands.spawn(GizmoBundle {
         transform: Transform::from_xyz(-4.0, 1.5, 0.0),
         gizmo: Gizmo {

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -329,7 +329,7 @@ pub fn empty() -> Mesh {
 }
 
 pub fn billboard() -> Mesh {
-    let mut mesh = Mesh::from(shape::Quad::new(Vec2::one()));
+    let mut mesh = Mesh::from(shape::Quad::new(Vec2::ONE));
 
     // Add vertex color (required by shader)
     mesh.set_attribute(Mesh::ATTRIBUTE_COLOR, {

--- a/src/line.rs
+++ b/src/line.rs
@@ -22,13 +22,13 @@ impl Line {
         };
 
         Self {
-            entity: commands
-                .spawn(GizmoMeshBundle {
+            entity: Some(commands
+                .spawn().insert_bundle(GizmoMeshBundle {
                     mesh: mesh_handle.clone(),
                     material: Color::WHITE.into(),
                     ..Default::default()
                 })
-                .current_entity(),
+                .id()),
             mesh_handle,
         }
     }

--- a/src/render_graph/screen_info_node.rs
+++ b/src/render_graph/screen_info_node.rs
@@ -1,18 +1,12 @@
 // TODO: Move rendering and pipeline stuff here
 
-use bevy::{
-    app::ManualEventReader,
-    core::AsBytes,
-    prelude::*,
-    render::{
+use bevy::{app::{Events, ManualEventReader}, core::AsBytes, prelude::*, render::{
         render_graph::{Node, ResourceSlots},
         renderer::{
             BufferId, BufferInfo, BufferMapMode, BufferUsage, RenderContext, RenderResourceBinding,
             RenderResourceBindings,
         },
-    },
-    window::{WindowCreated, WindowId, WindowResized},
-};
+    }, window::{WindowCreated, WindowId, WindowResized}};
 
 pub const SCREEN_INFO_NODE: &str = "screen_info";
 pub const SCREEN_INFO_UNIFORM: &str = "ScreenInfo";
@@ -30,7 +24,6 @@ impl Node for ScreenInfoNode {
     fn update(
         &mut self,
         _world: &World,
-        resources: &Resources,
         render_context: &mut dyn RenderContext,
         _input: &ResourceSlots,
         _output: &mut ResourceSlots,
@@ -38,10 +31,10 @@ impl Node for ScreenInfoNode {
         const BUFFER_SIZE: usize = std::mem::size_of::<[f32; 4]>();
 
         // Fetch resources
-        let window_created_events = resources.get::<Events<WindowCreated>>().unwrap();
-        let window_resized_events = resources.get::<Events<WindowResized>>().unwrap();
-        let windows = resources.get::<Windows>().unwrap();
-        let mut render_resource_bindings = resources.get_mut::<RenderResourceBindings>().unwrap();
+        let window_created_events = _world.get_resource::<Events<WindowCreated>>().unwrap();
+        let window_resized_events = _world.get_resource::<Events<WindowResized>>().unwrap();
+        let windows = _world.get_resource::<Windows>().unwrap();
+        let mut render_resource_bindings = _world.get_resource_mut::<RenderResourceBindings>().unwrap();
 
         let window = windows.get(self.window_id).unwrap();
 


### PR DESCRIPTION
Hey, I am just trying to fix these differences with bevy 0.5.

This is how far I got this evening. It seems like there is still something going on with the `RenderResourceBindings` in `screen_info_node.rs`.

Otherwise, most changes seemed trivial.

Also, are you discontinuing this? I find these gizmos quite nice. Thanks for making them.